### PR TITLE
Fix logging and reduce log level

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,13 @@ dependencies {
 
     implementation jcommander
 
-    implementation slf4j_api
+    implementation(slf4j_api_unversioned) {
+        version {
+            // Milton v3 raised SLF4J API version to a version unsupported by currently used
+            // logback version. Forcing downgrade.
+            strictly slf4j_version
+        }
+    }
 
     implementation javaxServlet
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,7 +21,8 @@ ext {
 
     commons_lang = 'org.apache.commons:commons-lang3:3.12.0'
 
-    slf4j_api = 'org.slf4j:slf4j-api:1.7.36'
+    slf4j_version = "1.7.32"
+    slf4j_api_unversioned = 'org.slf4j:slf4j-api'
     logback = 'ch.qos.logback:logback-classic:1.2.11'
 
     jetty_version = '10.0.11'

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Milton v3 raised SLF4J API version to a version unsupported by currently used logback version. Forcing downgrade.